### PR TITLE
Adiciona  para detecção de bloqueador de ads.

### DIFF
--- a/blockadblock.js
+++ b/blockadblock.js
@@ -1,0 +1,250 @@
+/*
+ * BlockAdBlock 3.2.1
+ * Copyright (c) 2015 Valentin Allaire <valentin.allaire@sitexw.fr>
+ * Released under the MIT license
+ * https://github.com/sitexw/BlockAdBlock
+ */
+
+(function(window) {
+	var BlockAdBlock = function(options) {
+		this._options = {
+			checkOnLoad:		false,
+			resetOnEnd:			false,
+			loopCheckTime:		50,
+			loopMaxNumber:		5,
+			baitClass:			'pub_300x250 pub_300x250m pub_728x90 text-ad textAd text_ad text_ads text-ads text-ad-links',
+			baitStyle:			'width: 1px !important; height: 1px !important; position: absolute !important; left: -10000px !important; top: -1000px !important;',
+			debug:				false
+		};
+		this._var = {
+			version:			'3.2.1',
+			bait:				null,
+			checking:			false,
+			loop:				null,
+			loopNumber:			0,
+			event:				{ detected: [], notDetected: [] }
+		};
+		if(options !== undefined) {
+			this.setOption(options);
+		}
+		var self = this;
+		var eventCallback = function() {
+			setTimeout(function() {
+				if(self._options.checkOnLoad === true) {
+					if(self._options.debug === true) {
+						self._log('onload->eventCallback', 'A check loading is launched');
+					}
+					if(self._var.bait === null) {
+						self._creatBait();
+					}
+					setTimeout(function() {
+						self.check();
+					}, 1);
+				}
+			}, 1);
+		};
+		if(window.addEventListener !== undefined) {
+			window.addEventListener('load', eventCallback, false);
+		} else {
+			window.attachEvent('onload', eventCallback);
+		}
+	};
+	BlockAdBlock.prototype._options = null;
+	BlockAdBlock.prototype._var = null;
+	BlockAdBlock.prototype._bait = null;
+	
+	BlockAdBlock.prototype._log = function(method, message) {
+		console.log('[BlockAdBlock]['+method+'] '+message);
+	};
+	
+	BlockAdBlock.prototype.setOption = function(options, value) {
+		if(value !== undefined) {
+			var key = options;
+			options = {};
+			options[key] = value;
+		}
+		for(var option in options) {
+			this._options[option] = options[option];
+			if(this._options.debug === true) {
+				this._log('setOption', 'The option "'+option+'" he was assigned to "'+options[option]+'"');
+			}
+		}
+		return this;
+	};
+	
+	BlockAdBlock.prototype._creatBait = function() {
+		var bait = document.createElement('div');
+			bait.setAttribute('class', this._options.baitClass);
+			bait.setAttribute('style', this._options.baitStyle);
+		this._var.bait = window.document.body.appendChild(bait);
+		
+		this._var.bait.offsetParent;
+		this._var.bait.offsetHeight;
+		this._var.bait.offsetLeft;
+		this._var.bait.offsetTop;
+		this._var.bait.offsetWidth;
+		this._var.bait.clientHeight;
+		this._var.bait.clientWidth;
+		
+		if(this._options.debug === true) {
+			this._log('_creatBait', 'Bait has been created');
+		}
+	};
+	BlockAdBlock.prototype._destroyBait = function() {
+		window.document.body.removeChild(this._var.bait);
+		this._var.bait = null;
+		
+		if(this._options.debug === true) {
+			this._log('_destroyBait', 'Bait has been removed');
+		}
+	};
+	
+	BlockAdBlock.prototype.check = function(loop) {
+		if(loop === undefined) {
+			loop = true;
+		}
+		
+		if(this._options.debug === true) {
+			this._log('check', 'An audit was requested '+(loop===true?'with a':'without')+' loop');
+		}
+		
+		if(this._var.checking === true) {
+			if(this._options.debug === true) {
+				this._log('check', 'A check was canceled because there is already an ongoing');
+			}
+			return false;
+		}
+		this._var.checking = true;
+		
+		if(this._var.bait === null) {
+			this._creatBait();
+		}
+		
+		var self = this;
+		this._var.loopNumber = 0;
+		if(loop === true) {
+			this._var.loop = setInterval(function() {
+				self._checkBait(loop);
+			}, this._options.loopCheckTime);
+		}
+		setTimeout(function() {
+			self._checkBait(loop);
+		}, 1);
+		if(this._options.debug === true) {
+			this._log('check', 'A check is in progress ...');
+		}
+		
+		return true;
+	};
+	BlockAdBlock.prototype._checkBait = function(loop) {
+		var detected = false;
+		
+		if(this._var.bait === null) {
+			this._creatBait();
+		}
+		
+		if(window.document.body.getAttribute('abp') !== null
+		|| this._var.bait.offsetParent === null
+		|| this._var.bait.offsetHeight == 0
+		|| this._var.bait.offsetLeft == 0
+		|| this._var.bait.offsetTop == 0
+		|| this._var.bait.offsetWidth == 0
+		|| this._var.bait.clientHeight == 0
+		|| this._var.bait.clientWidth == 0) {
+			detected = true;
+		}
+		if(window.getComputedStyle !== undefined) {
+			var baitTemp = window.getComputedStyle(this._var.bait, null);
+			if(baitTemp && (baitTemp.getPropertyValue('display') == 'none' || baitTemp.getPropertyValue('visibility') == 'hidden')) {
+				detected = true;
+			}
+		}
+		
+		if(this._options.debug === true) {
+			this._log('_checkBait', 'A check ('+(this._var.loopNumber+1)+'/'+this._options.loopMaxNumber+' ~'+(1+this._var.loopNumber*this._options.loopCheckTime)+'ms) was conducted and detection is '+(detected===true?'positive':'negative'));
+		}
+		
+		if(loop === true) {
+			this._var.loopNumber++;
+			if(this._var.loopNumber >= this._options.loopMaxNumber) {
+				this._stopLoop();
+			}
+		}
+		
+		if(detected === true) {
+			this._stopLoop();
+			this._destroyBait();
+			this.emitEvent(true);
+			if(loop === true) {
+				this._var.checking = false;
+			}
+		} else if(this._var.loop === null || loop === false) {
+			this._destroyBait();
+			this.emitEvent(false);
+			if(loop === true) {
+				this._var.checking = false;
+			}
+		}
+	};
+	BlockAdBlock.prototype._stopLoop = function(detected) {
+		clearInterval(this._var.loop);
+		this._var.loop = null;
+		this._var.loopNumber = 0;
+		
+		if(this._options.debug === true) {
+			this._log('_stopLoop', 'A loop has been stopped');
+		}
+	};
+	
+	BlockAdBlock.prototype.emitEvent = function(detected) {
+		if(this._options.debug === true) {
+			this._log('emitEvent', 'An event with a '+(detected===true?'positive':'negative')+' detection was called');
+		}
+		
+		var fns = this._var.event[(detected===true?'detected':'notDetected')];
+		for(var i in fns) {
+			if(this._options.debug === true) {
+				this._log('emitEvent', 'Call function '+(parseInt(i)+1)+'/'+fns.length);
+			}
+			if(fns.hasOwnProperty(i)) {
+				fns[i]();
+			}
+		}
+		if(this._options.resetOnEnd === true) {
+			this.clearEvent();
+		}
+		return this;
+	};
+	BlockAdBlock.prototype.clearEvent = function() {
+		this._var.event.detected = [];
+		this._var.event.notDetected = [];
+		
+		if(this._options.debug === true) {
+			this._log('clearEvent', 'The event list has been cleared');
+		}
+	};
+	
+	BlockAdBlock.prototype.on = function(detected, fn) {
+		this._var.event[(detected===true?'detected':'notDetected')].push(fn);
+		if(this._options.debug === true) {
+			this._log('on', 'A type of event "'+(detected===true?'detected':'notDetected')+'" was added');
+		}
+		
+		return this;
+	};
+	BlockAdBlock.prototype.onDetected = function(fn) {
+		return this.on(true, fn);
+	};
+	BlockAdBlock.prototype.onNotDetected = function(fn) {
+		return this.on(false, fn);
+	};
+	
+	window.BlockAdBlock = BlockAdBlock;
+	
+	if(window.blockAdBlock === undefined) {
+		window.blockAdBlock = new BlockAdBlock({
+			checkOnLoad: true,
+			resetOnEnd: true
+		});
+	}
+})(window);

--- a/index.html
+++ b/index.html
@@ -41,10 +41,23 @@
     line-height: 60px; /* Vertically center the text there */
     background-color: #404040;
   }
+
+  #banner_blockad {
+    display: none;
+    margin-bottom: 0px;
+    padding: 20px 10px;
+    background: #230002;
+    text-align: center;
+    font-weight: bold;
+    color: #fff;
+  }
   </style>
 </head>
 <body>
-
+  <div id="banner_blockad">
+    Nosso site necessita de que você desabilite o seu plugin AdBlock para vizualição dos links de livros.<br>
+    Obrigado por contribuir com o Paiol.
+  </div>
   <!-- Navbar-->
   <nav class="navbar navbar-toggleable-md navbar-inverse bg-inverse">
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarNav"
@@ -88,43 +101,43 @@
 
   <div class="row">
     <div class="col-md-3 col-6">
-     <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8521312369&asins=8521312369&linkId=4bbcf1fb7596fee4b4aa1d77fb8d4886&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+     <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8521312369&asins=8521312369&linkId=4bbcf1fb7596fee4b4aa1d77fb8d4886&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
      <div class="col-md-3 col-6">
-      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8573038411&asins=8573038411&linkId=0b6674f0f1fa21ecf0d01380a422fbec&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8573038411&asins=8573038411&linkId=0b6674f0f1fa21ecf0d01380a422fbec&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
      <div class="col-md-3 col-6">
-      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8571838267&asins=8571838267&linkId=2c3b6ceb3b36594924138fd0c70b9f84&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8571838267&asins=8571838267&linkId=2c3b6ceb3b36594924138fd0c70b9f84&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
      <div class="col-md-3 col-6">
-      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=853900383X&asins=853900383X&linkId=4194807c08a90ea1f667601e395d335f&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=853900383X&asins=853900383X&linkId=4194807c08a90ea1f667601e395d335f&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
     <div class="col-md-3 col-6">
-      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=858057952X&asins=858057952X&linkId=b0373f156f84b3016757e78f9c886977&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=858057952X&asins=858057952X&linkId=b0373f156f84b3016757e78f9c886977&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
     <div class="col-md-3 col-6">
-      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8537814210&asins=8537814210&linkId=422519a247f5713c8da4c03ee334d2da&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8537814210&asins=8537814210&linkId=422519a247f5713c8da4c03ee334d2da&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
       </iframe>
     </div>
     <div class="col-md-3 col-6">
-      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8537813516&asins=8537813516&linkId=ae5f9695be16a0292c0e3c4777a893c5&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8537813516&asins=8537813516&linkId=ae5f9695be16a0292c0e3c4777a893c5&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
       </iframe>
     </div>
     <div class="col-md-3 col-6">
-      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8537801550&asins=8537801550&linkId=a28ba219e27c87a5832d0266ce7ef64f&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8537801550&asins=8537801550&linkId=a28ba219e27c87a5832d0266ce7ef64f&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
       </iframe>
     </div>
     <div class="col-md-3 col-6">
-      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=853780116X&asins=853780116X&linkId=1cd1e3c1419adbebafc8d2934d7783ae&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=853780116X&asins=853780116X&linkId=1cd1e3c1419adbebafc8d2934d7783ae&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
     <div class="col-md-3 col-6">
-      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=B01FG8YYSE&asins=B01FG8YYSE&linkId=94e39bff0be54102b495844effdbd533&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=B01FG8YYSE&asins=B01FG8YYSE&linkId=94e39bff0be54102b495844effdbd533&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
   </div>
@@ -140,43 +153,43 @@
 
   <div class="row">
     <div class="col-md-3 col-6">
-    <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8575225634&asins=8575225634&linkId=5badf05a7b9912941a95e18dd60d8ac0&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+    <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8575225634&asins=8575225634&linkId=5badf05a7b9912941a95e18dd60d8ac0&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
      <div class="col-md-3 col-6">
-      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=857522462X&asins=857522462X&linkId=b9b0ad8714e179df7eab8cb5a919a2f9&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=857522462X&asins=857522462X&linkId=b9b0ad8714e179df7eab8cb5a919a2f9&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
      <div class="col-md-3 col-6">
-      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=857608998X&asins=857608998X&linkId=03ff93f3e5927cf4305760031bf08d3d&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=857608998X&asins=857608998X&linkId=03ff93f3e5927cf4305760031bf08d3d&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
      <div class="col-md-3 col-6">
-      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8575225081&asins=8575225081&linkId=35ed9ff8a9167dddce1f12b869d16c4c&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8575225081&asins=8575225081&linkId=35ed9ff8a9167dddce1f12b869d16c4c&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
     <div class="col-md-3 col-6">
-      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8575224085&asins=8575224085&linkId=dfc118ea1ef4ccb571326497b55fe10b&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+      <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8575224085&asins=8575224085&linkId=dfc118ea1ef4ccb571326497b55fe10b&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
     <div class="col-md-3 col-6">
-    <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8575224468&asins=8575224468&linkId=42c7dc583e3c796511191baaaafb34c0&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+    <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8575224468&asins=8575224468&linkId=42c7dc583e3c796511191baaaafb34c0&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
     <div class="col-md-3 col-6">
-    <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8575224743&asins=8575224743&linkId=e5ed4baa30112aebb83b8386a3053d3a&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+    <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8575224743&asins=8575224743&linkId=e5ed4baa30112aebb83b8386a3053d3a&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
     <div class="col-md-3 col-6">
-    <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=B01M4P01VI&asins=B01M4P01VI&linkId=d736575d3ef443c7ca6bcd53db933507&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+    <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=B01M4P01VI&asins=B01M4P01VI&linkId=d736575d3ef443c7ca6bcd53db933507&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
     <div class="col-md-3 col-6">
-    <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8575221523&asins=8575221523&linkId=ad86db28191451125629bc2a6fbf8c15&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+    <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8575221523&asins=8575221523&linkId=ad86db28191451125629bc2a6fbf8c15&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
     <div class="col-md-3 col-6">
-    <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="//ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8576087995&asins=8576087995&linkId=999da1fb472392a65533312afaa17b57&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
+    <iframe style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" frameborder="0" src="ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=BR&source=ac&ref=qf_sp_asin_til&ad_type=product_link&tracking_id=wttd4242-20&marketplace=amazon&region=BR&placement=8576087995&asins=8576087995&linkId=999da1fb472392a65533312afaa17b57&show_border=false&link_opens_in_new_window=true&price_color=333333&title_color=004a8f&bg_color=ffffff">
     </iframe>
     </div>
   </div>
@@ -205,5 +218,34 @@
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js"
           integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn"
           crossorigin="anonymous"></script>
+
+  <script>var blockAdBlock = false;</script>
+  <script src="./blockadblock.js"></script>
+  <script type="text/javascript">
+    blockAdBlock = new BlockAdBlock({
+      checkOnLoad: true,
+      resetOnEnd: true
+    });
+    // Function called if an AdBlock is not detected
+    function adBlockNotDetected() {
+      console.log('AdBlock is not enabled');
+      document.getElementById('banner_blockad').style.display='none';
+    }
+    // Function called if an AdBlock is detected
+    function adBlockDetected() {
+      console.log('AdBlock is enabled');
+      document.getElementById('banner_blockad').style.display='block';
+    }
+
+    // Recommended audit because AdBlock lock the file 'blockadblock.js' 
+    // If the file is not called, the variable does not exist 'blockAdBlock'
+    // This means that AdBlock is present
+    if(typeof blockAdBlock === 'undefined') {
+      adBlockDetected();
+    } else {
+      blockAdBlock.onDetected(adBlockDetected);
+      blockAdBlock.onNotDetected(adBlockNotDetected);
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Usando a lib JS blockadblock (https://github.com/sitexw/BlockAdBlock) para detectar se o usuário está com algum plugin ou extensão bloqueadora de Ads no seu browser. Para fins de testes foi usado o método blockAdBlock.emitEvent(test), onde é possível acionar ou não a presença de adblock.
Como isso teremos uma forma de lembrar o usuário que o possível motivo de ele não estar vendo os links de compra dos livros é a presença do Aadblock